### PR TITLE
Fix to allow API7 to use ShowcaseView

### DIFF
--- a/library/src/com/github/espiandev/showcaseview/ShowcaseView.java
+++ b/library/src/com/github/espiandev/showcaseview/ShowcaseView.java
@@ -1,5 +1,6 @@
 package com.github.espiandev.showcaseview;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -464,6 +465,7 @@ public class ShowcaseView extends RelativeLayout implements View.OnClickListener
 
 	}
 
+	@SuppressLint("NewApi")
 	@Override
 	public void onClick(View view) {
 		// If the type is set to one-shot, store that it has shot
@@ -608,12 +610,26 @@ public class ShowcaseView extends RelativeLayout implements View.OnClickListener
 
 		ObjectAnimator alphaIn = ObjectAnimator.ofFloat(mHandy, "alpha", 0f, 1f).setDuration(500);
 
-		ObjectAnimator setUpX = ObjectAnimator.ofFloat(mHandy, "x", view.getX() + view.getWidth() / 2).setDuration(0);
-		ObjectAnimator setUpY = ObjectAnimator.ofFloat(mHandy, "y", view.getY() + view.getHeight() / 2).setDuration(0);
+		ObjectAnimator setUpX = ObjectAnimator.ofFloat(mHandy, "x", getXfromView(view) + view.getWidth() / 2).setDuration(0);
+		ObjectAnimator setUpY = ObjectAnimator.ofFloat(mHandy, "y", getYfromView(view) + view.getHeight() / 2).setDuration(0);
 
 		AnimatorSet as = new AnimatorSet();
 		as.play(setUpX).with(setUpY).before(alphaIn);
 		as.start();
+	}
+
+	@SuppressLint("NewApi")
+	private float getXfromView(View view) {
+		if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB)
+			return view.getX();
+		return view.getLeft();
+	}
+
+	@SuppressLint("NewApi")
+	private float getYfromView(View view) {
+		if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB)
+			return view.getY();
+		return view.getTop();
 	}
 
 	/**
@@ -806,3 +822,4 @@ public class ShowcaseView extends RelativeLayout implements View.OnClickListener
 	}
 
 }
+


### PR DESCRIPTION
Tested in an emulator only, but this quick fix allows devices down to API7 to use Showcase.

![RandomShowcase](https://f.cloud.github.com/assets/387759/179101/26127b2a-7be5-11e2-99d8-c585f82f9f76.png)
