### PR TITLE
Handle case where button already exists in the view

### DIFF
--- a/library/src/com/github/espiandev/showcaseview/ShowcaseView.java
+++ b/library/src/com/github/espiandev/showcaseview/ShowcaseView.java
@@ -121,7 +121,7 @@ public class ShowcaseView extends RelativeLayout implements View.OnClickListener
 		mEraser.setAlpha(0);
 		mEraser.setXfermode(mBlender);
 
-		if (!mOptions.noButton) {
+		if (!mOptions.noButton && (findViewById(R.id.showcase_button) == null)) {
 			RelativeLayout.LayoutParams lps = (LayoutParams) generateDefaultLayoutParams();
 			lps.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
 			lps.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);


### PR DESCRIPTION
co.hideOnClickOutside = Boolean.FALSE;
co.shotType = ShowcaseView.TYPE_NO_LIMIT;
co.insert = ShowcaseView.INSERT_TO_DECOR;

sv.setText(title, sub);
sv.setShowcaseView(v);

Given this as the context, when i try to update the scv to point to different views, 
an IllegalStateException gets thrown at line 135 because the button already exists and you are trying to add it again. In order to avoid this, i just made a simple check for its existence.

The alternative method would be is to keep track of additon with a boolean flag.