### PR TITLE
Prefix attributes to avoid clashes with other libraries

### DIFF
--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -1,13 +1,15 @@
 <resources>
+
     <declare-styleable name="ShowcaseView">
-        <attr name="backgroundColor" format="color|reference" />
-        <attr name="detailTextColor" format="color|reference" />
-        <attr name="titleTextColor" format="color|reference" />
-        <attr name="buttonBackgroundColor" format="color|reference" />
-        <attr name="buttonForegroundColor" format="color|reference" />
-        <attr name="buttonText" format="string|reference" />
+        <attr name="sv_backgroundColor" format="color|reference" />
+        <attr name="sv_detailTextColor" format="color|reference" />
+        <attr name="sv_titleTextColor" format="color|reference" />
+        <attr name="sv_buttonBackgroundColor" format="color|reference" />
+        <attr name="sv_buttonForegroundColor" format="color|reference" />
+        <attr name="sv_buttonText" format="string|reference" />
     </declare-styleable>
     <declare-styleable name="CustomTheme">
         <attr name="showcaseViewStyle" format="reference" />
     </declare-styleable>
+
 </resources>

--- a/library/res/values/styles.xml
+++ b/library/res/values/styles.xml
@@ -11,6 +11,7 @@
         <item name="android:textColor">#FFFFFF</item>
         <item name="android:background">@drawable/cling_button_bg</item>
     </style>
+
     <style name="ShowcaseTitleText">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
@@ -21,6 +22,7 @@
         <item name="android:shadowDy">2</item>
         <item name="android:shadowRadius">2.0</item>
     </style>
+
     <style name="ShowcaseText">
         <item name="android:textSize">15sp</item>
         <item name="android:textColor">#FFFFFF</item>
@@ -31,17 +33,17 @@
     </style>
 
     <style name="ShowcaseView.Light">
-        <item name="titleTextColor">#33B5E5</item>
-        <item name="detailTextColor">#444</item>
-        <item name="backgroundColor">#3333B5E5</item>
-        <item name="buttonText">@string/ok</item>
+        <item name="sv_titleTextColor">#33B5E5</item>
+        <item name="sv_detailTextColor">#444</item>
+        <item name="sv_backgroundColor">#3333B5E5</item>
+        <item name="sv_buttonText">@string/ok</item>
     </style>
 
     <style name="ShowcaseView">
-        <item name="titleTextColor">#33B5E5</item>
-        <item name="detailTextColor">#FFFFFF</item>
-        <item name="backgroundColor">#3333B5E5</item>
-        <item name="buttonText">@string/ok</item>
+        <item name="sv_titleTextColor">#33B5E5</item>
+        <item name="sv_detailTextColor">#FFFFFF</item>
+        <item name="sv_backgroundColor">#3333B5E5</item>
+        <item name="sv_buttonText">@string/ok</item>
     </style>
 
 </resources>

--- a/library/src/com/github/espiandev/showcaseview/ShowcaseView.java
+++ b/library/src/com/github/espiandev/showcaseview/ShowcaseView.java
@@ -1,11 +1,19 @@
 package com.github.espiandev.showcaseview;
 
+import java.lang.reflect.Field;
+
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.TypedArray;
-import android.graphics.*;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
+import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Handler;
@@ -14,15 +22,18 @@ import android.text.Layout;
 import android.text.TextPaint;
 import android.text.TextUtils;
 import android.util.AttributeSet;
-import android.view.*;
+import android.view.LayoutInflater;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
 import android.widget.Button;
 import android.widget.RelativeLayout;
+
 import com.nineoldandroids.animation.Animator;
 import com.nineoldandroids.animation.AnimatorSet;
 import com.nineoldandroids.animation.ObjectAnimator;
 import com.nineoldandroids.view.ViewHelper;
-
-import java.lang.reflect.Field;
 
 /**
  * A view which allows you to showcase areas of your app with an explanation.
@@ -80,10 +91,10 @@ public class ShowcaseView extends RelativeLayout implements View.OnClickListener
 		// Get the attributes for the ShowcaseView
 		final TypedArray styled = context.getTheme().obtainStyledAttributes(attrs, R.styleable.ShowcaseView,
 				R.attr.showcaseViewStyle, R.style.ShowcaseView);
-		backColor = styled.getInt(R.styleable.ShowcaseView_backgroundColor, Color.argb(128, 80, 80, 80));
-		detailTextColor = styled.getColor(R.styleable.ShowcaseView_detailTextColor, Color.WHITE);
-		titleTextColor = styled.getColor(R.styleable.ShowcaseView_titleTextColor, Color.parseColor("#49C0EC"));
-		buttonText = styled.getString(R.styleable.ShowcaseView_buttonText);
+                backColor = styled.getInt(R.styleable.ShowcaseView_sv_backgroundColor, Color.argb(128, 80, 80, 80));
+                detailTextColor = styled.getColor(R.styleable.ShowcaseView_sv_detailTextColor, Color.WHITE);
+                titleTextColor = styled.getColor(R.styleable.ShowcaseView_sv_titleTextColor, Color.parseColor("#49C0EC"));
+                buttonText = styled.getString(R.styleable.ShowcaseView_sv_buttonText);
 		styled.recycle();
 
 		metricScale = getContext().getResources().getDisplayMetrics().density;

--- a/sample/res/values/styles.xml
+++ b/sample/res/values/styles.xml
@@ -1,11 +1,12 @@
+<?xml version="1.0"?>
 <resources xmlns:showcase="http://schemas.android.com/apk/res-auto">
-    <style name="CustomShowcaseTheme" parent="ShowcaseView.Light">
-        <item name="titleTextColor">#ffbb33</item>
-        <item name="backgroundColor">#33ffbb33</item>
-        <item name="buttonBackgroundColor">#CF3119</item>
-        <item name="buttonText">Close</item>
-    </style>
-    <style name="SampleTheme" parent="Theme.Sherlock.Light.DarkActionBar">
-        <item name="showcaseViewStyle">@style/CustomShowcaseTheme</item>
-    </style>
+  <style name="CustomShowcaseTheme" parent="ShowcaseView.Light">
+    <item name="sv_titleTextColor">#ffbb33</item>
+    <item name="sv_backgroundColor">#33ffbb33</item>
+    <item name="sv_buttonBackgroundColor">#CF3119</item>
+    <item name="sv_buttonText">Close</item>
+  </style>
+  <style name="SampleTheme" parent="Theme.Sherlock.Light.DarkActionBar">
+    <item name="showcaseViewStyle">@style/CustomShowcaseTheme</item>
+  </style>
 </resources>


### PR DESCRIPTION
Some of the attribute names were clashing with another library I was using so I prefixed them to prevent this.
