### PR TITLE
Fix so the Support Library is not needed 

### DIFF
--- a/sample/src/com/github/espiandev/showcaseview/sample/v14/ActionItemsSampleActivity.java
+++ b/sample/src/com/github/espiandev/showcaseview/sample/v14/ActionItemsSampleActivity.java
@@ -1,14 +1,14 @@
 package com.github.espiandev.showcaseview.sample.v14;
 
+import android.app.Activity;
 import android.os.Bundle;
-import android.support.v4.app.FragmentActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 
 import com.github.espiandev.showcaseview.ShowcaseView;
 import com.github.espiandev.showcaseview.sample.R;
 
-public class ActionItemsSampleActivity extends FragmentActivity {
+public class ActionItemsSampleActivity extends Activity {
 
     ShowcaseView sv;
     ShowcaseView.ConfigOptions mOptions = new ShowcaseView.ConfigOptions();


### PR DESCRIPTION
This was done by extending Activity and not FragmentActivity. The Activity is for v14 only anyways.
