### PR TITLE
Ability to block all touches, including within the showcased view circle

### DIFF
--- a/library/src/com/github/espiandev/showcaseview/ShowcaseView.java
+++ b/library/src/com/github/espiandev/showcaseview/ShowcaseView.java
@@ -581,6 +581,10 @@ public class ShowcaseView extends RelativeLayout implements View.OnClickListener
             return true;
         }
 
+        if (mOptions.blockAll) {
+            return true;
+        }
+
         return mOptions.block && distanceFromFocus > showcaseRadius;
     }
 
@@ -814,7 +818,7 @@ public class ShowcaseView extends RelativeLayout implements View.OnClickListener
     }
 
     public static class ConfigOptions {
-        public boolean block = true, noButton = false;
+        public boolean blockAll = true, block = true, noButton = false;
         public int showcaseId = 0;
         public int shotType = TYPE_NO_LIMIT;
         public int insert = INSERT_TO_DECOR;


### PR DESCRIPTION
There was no way to pass custom `ConfigOptions` from `ShowcaseViews` to `ShowcaseView`, so this commit changes the defaults. If there's a better way, please...

I don't like changing default behavior, but I do believe this is a better default due to the current behavior of the showcase when clicking inside the circle (it doesn't go away, and if you use `ShowcaseViews` it's even worst).