### PR TITLE
Fix NullPointerException when using pointTo

### DIFF
--- a/library/src/com/github/espiandev/showcaseview/ShowcaseView.java
+++ b/library/src/com/github/espiandev/showcaseview/ShowcaseView.java
@@ -644,6 +644,7 @@ public class ShowcaseView extends RelativeLayout implements View.OnClickListener
      * @param y Y-coordinate to point to
      */
     public void pointTo(float x, float y) {
+		final View mHandy = ((LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE)).inflate(R.layout.handy, null);
         AnimationUtils.createMovementAnimation(mHandy, x, y).start();
     }
 


### PR DESCRIPTION
Using pointTo caused a NullPointerException as mHandy was not defined before.

maybe missing code in pointTo or forgot to add mHandy to the "private View mHandy;" when calling getHand() ?
