### PR TITLE
Fixed layout for titles which are longer than one line

### DIFF
--- a/library/src/com/github/espiandev/showcaseview/ShowcaseView.java
+++ b/library/src/com/github/espiandev/showcaseview/ShowcaseView.java
@@ -437,7 +437,7 @@ public class ShowcaseView extends RelativeLayout implements View.OnClickListener
                             ((Number) mBestTextPosition[2]).intValue(), Layout.Alignment.ALIGN_NORMAL,
                             1.2f, 1.0f, true);
                 }
-                canvas.translate(mBestTextPosition[0], mBestTextPosition[1] + 12 * metricScale);
+                canvas.translate(mBestTextPosition[0] , mBestTextPosition[1] + 12 * metricScale + (mDynamicTitleLayout.getLineBottom(mDynamicTitleLayout.getLineCount()-1)-mDynamicTitleLayout.getLineBottom(0)));
                 mDynamicDetailLayout.draw(canvas);
                 canvas.restore();
 


### PR DESCRIPTION
This solution was originally posted by SimplicityApks here: http://forum.xda-developers.com/showthread.php?p=45888213#post45888213

All credits to him. (He asked me to create a pull request.)

Quote:

> I found an easy solution for the bug where a ShowcaseView title which is longer than one line overlaps the detailText:
> replace line 440 of the ShowcaseView.class, in the dispatchDraw(Canvas canvas) method with this:
> Code:
> canvas.translate(mBestTextPosition[0] , mBestTextPosition[1] + 12 \* metricScale + (mDynamicTitleLayout.getLineBottom(mDynamicTitleLayout.getLineCount()-1)-mDynamicTitleLayout.getLineBottom(0)));
