### PR TITLE
Fixed onShowcaseViewHide being called multiple times

### DIFF
--- a/library/src/com/espian/showcaseview/ShowcaseView.java
+++ b/library/src/com/espian/showcaseview/ShowcaseView.java
@@ -497,7 +497,8 @@ public class ShowcaseView extends RelativeLayout
         float yDelta = Math.abs(motionEvent.getRawY() - showcaseY);
         double distanceFromFocus = Math.sqrt(Math.pow(xDelta, 2) + Math.pow(yDelta, 2));
 
-        if (mOptions.hideOnClickOutside && distanceFromFocus > showcaseRadius) {
+        if (MotionEvent.ACTION_UP == motionEvent.getAction() &&
+            mOptions.hideOnClickOutside && distanceFromFocus > showcaseRadius) {
             this.hide();
             return true;
         }


### PR DESCRIPTION
Only hiding the showcase on ACTION_UP. Right now the showcase tries to hide on all types of onTouch events (up, down, move).

I chose ACTION_UP over ACTION_DOWN because it allows the user to slide their finger off the screen or to the showcased object to have the showcase not dismiss. 

This fixes #91
