### PR TITLE
pointTo in ShowcaseView creates and adds hand properly

### DIFF
--- a/library/src/com/espian/showcaseview/ShowcaseView.java
+++ b/library/src/com/espian/showcaseview/ShowcaseView.java
@@ -562,8 +562,7 @@ public class ShowcaseView extends RelativeLayout
      * @param y Y-coordinate to point to
      */
     public void pointTo(float x, float y) {
-        final View mHandy = ((LayoutInflater) getContext()
-                .getSystemService(Context.LAYOUT_INFLATER_SERVICE)).inflate(R.layout.handy, null);
+        mHandy = getHand();
         AnimationUtils.createMovementAnimation(mHandy, x, y).start();
     }
 


### PR DESCRIPTION
Bugfix for pointTo method in ShowcaseView

PointTo creates and animates a hand locally and is therefore not displayed.

Instead I use getHand which creates and adds the hand properly.
