### PR TITLE
Fix: trouble if more than ONE_SHOT showcases are create in the same activity.

### DIFF
--- a/library/src/com/espian/showcaseview/ShowcaseView.java
+++ b/library/src/com/espian/showcaseview/ShowcaseView.java
@@ -114,13 +114,12 @@ public class ShowcaseView extends RelativeLayout
         init();
     }
 
-    private void init() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            setLayerType(LAYER_TYPE_SOFTWARE, null);
-        } else {
-            setDrawingCacheEnabled(true);
-        }
-
+    /**
+     * Tell if we want to visualize the run.
+     *
+     * @return if the
+     */
+    private boolean configureVisibility() {
         boolean hasShot = getContext()
                 .getSharedPreferences(PREFS_SHOWCASE_INTERNAL, Context.MODE_PRIVATE)
                 .getBoolean("hasShot" + getConfigOptions().showcaseId, false);
@@ -128,7 +127,17 @@ public class ShowcaseView extends RelativeLayout
             // The showcase has already been shot once, so we don't need to do anything
             setVisibility(View.GONE);
             isRedundant = true;
-            return;
+            return false;
+        }
+
+        return true;
+    }
+
+    private void init() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            setLayerType(LAYER_TYPE_SOFTWARE, null);
+        } else {
+            setDrawingCacheEnabled(true);
         }
 
         showcaseRadius = metricScale * INNER_CIRCLE_RADIUS;
@@ -469,6 +478,8 @@ public class ShowcaseView extends RelativeLayout
     }
 
     public void show() {
+        if (!configureVisibility())
+            return;
         if (mEventListener != null) {
             mEventListener.onShowcaseViewShow(this);
         }
@@ -596,6 +607,8 @@ public class ShowcaseView extends RelativeLayout
         if (options != null) {
             sv.setConfigOptions(options);
         }
+        if (!sv.configureVisibility())
+            return sv;
         if (sv.getConfigOptions().insert == INSERT_TO_DECOR) {
             ((ViewGroup) activity.getWindow().getDecorView()).addView(sv);
         } else {

--- a/library/src/com/espian/showcaseview/ShowcaseViews.java
+++ b/library/src/com/espian/showcaseview/ShowcaseViews.java
@@ -93,22 +93,10 @@ public class ShowcaseViews {
         }
         final ShowcaseView view = views.get(0);
 
-        boolean hasShot = activity.getSharedPreferences(ShowcaseView.PREFS_SHOWCASE_INTERNAL, Context.MODE_PRIVATE)
-                .getBoolean("hasShot" + view.getConfigOptions().showcaseId, false);
-        if (hasShot && view.getConfigOptions().shotType == ShowcaseView.TYPE_ONE_SHOT) {
-            // The showcase has already been shot once, so we don't need to do show it again.
-            view.setVisibility(View.GONE);
-            views.remove(0);
-            view.getConfigOptions().fadeOutDuration = 0;
-            view.performButtonClick();
-            return;
-        }
-
         view.setVisibility(View.INVISIBLE);
         ((ViewGroup) activity.getWindow().getDecorView()).addView(view);
         view.show();
         views.remove(0);
-
     }
 
     public boolean hasViews(){


### PR DESCRIPTION
The code to chose if show or not the showcase is too early in code. We
factorize it and check later at showing time. This is a common problem
for this library, see https://github.com/Espiandev/ShowcaseView/issues/71.

NOTE: this breaks the ShowcaseViews behaviour, as workaround you have to set explicitly the `showcaseId`.

This is a dirty workaround for an application I working on, suggestions are welcome.
