### PR TITLE
Fixes amlcurran/ShowcaseView#119

### DIFF
--- a/library/src/com/espian/showcaseview/ShowcaseView.java
+++ b/library/src/com/espian/showcaseview/ShowcaseView.java
@@ -358,13 +358,17 @@ public class ShowcaseView extends RelativeLayout
 
     public void setHardwareAccelerated(boolean accelerated) {
         if (accelerated) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-                Paint hardwarePaint = new Paint();
-                hardwarePaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.OVERLAY));
-                setLayerType(LAYER_TYPE_HARDWARE, hardwarePaint);
-            } else {
-                setDrawingCacheEnabled(false);
-            }
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+				if (isHardwareAccelerated()) {
+					Paint hardwarePaint = new Paint();
+					hardwarePaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.OVERLAY));
+					setLayerType(LAYER_TYPE_HARDWARE, hardwarePaint);
+				} else {
+					setLayerType(LAYER_TYPE_SOFTWARE, null);
+				}
+			} else {
+				setDrawingCacheEnabled(true);
+			}
         } else {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
                 setLayerType(LAYER_TYPE_SOFTWARE, null);


### PR DESCRIPTION
I am tested on several devices, but these never were hardware accelerated. The true part of the isHardwareAccelerated() statement never reached, but this causes error in the emulator.

Now looks good on these devices:
Samsung Galaxy Nexus 10 (4.2.2)
Xperia Mini Pro (4.4.1)
Samung Galaxy Y - GT-S5360 (2.3.6)
Emulator (4.0.4)
