### PR TITLE
Fixed options not used on init

### DIFF
--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -4,6 +4,6 @@
     android:versionCode="1"
     android:versionName="1.0">
 
-    <uses-sdk android:minSdkVersion="4" android:targetSdkVersion="19" />
+    <uses-sdk android:minSdkVersion="4" android:targetSdkVersion="17" />
 
 </manifest>

--- a/library/res/layout/showcase_button.xml
+++ b/library/res/layout/showcase_button.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Button xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/ShowcaseButton"
+    style="?attr/sv_showcaseButtonStyle"
     android:text="@string/ok"
     android:id="@id/showcase_button" />

--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -10,9 +10,12 @@
         <attr name="sv_detailTextAppearance" format="reference" />
         <attr name="sv_titleTextAppearance" format="reference" />
         <attr name="sv_showcaseColor" format="color|reference" />
+
+        <attr name="sv_showcaseButtonStyle" format="reference" />
     </declare-styleable>
     <declare-styleable name="CustomTheme">
         <attr name="showcaseViewStyle" format="reference" />
     </declare-styleable>
+
 
 </resources>

--- a/library/res/values/styles.xml
+++ b/library/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <style name="ShowcaseButton">
+    <style name="ShowcaseButton" parent="android:style/Widget.Button">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:paddingTop">10dp</item>
@@ -12,18 +12,22 @@
         <item name="android:background">@drawable/cling_button_bg</item>
     </style>
 
-    <style name="ShowcaseView.Light">
+    <style name="ShowcaseView.Light" >
         <item name="sv_titleTextAppearance">@style/TextAppearance.ShowcaseView.Title</item>
         <item name="sv_detailTextAppearance">@style/TextAppearance.ShowcaseView.Detail.Light</item>
         <item name="sv_backgroundColor">#3333B5E5</item>
         <item name="sv_buttonText">@string/ok</item>
+        <item name="sv_showcaseButtonStyle">@style/ShowcaseButton</item>
+        <!--<item name="android:buttonStyle">?attr/sv_showcaseButtonStyle</item>-->
     </style>
 
-    <style name="ShowcaseView">
+    <style name="ShowcaseView" >
         <item name="sv_titleTextAppearance">@style/TextAppearance.ShowcaseView.Title</item>
         <item name="sv_detailTextAppearance">@style/TextAppearance.ShowcaseView.Detail</item>
         <item name="sv_backgroundColor">#3333B5E5</item>
         <item name="sv_buttonText">@string/ok</item>
+        <item name="sv_showcaseButtonStyle">@style/ShowcaseButton</item>
+        <!--<item name="android:buttonStyle">?attr/sv_showcaseButtonStyle</item>-->
     </style>
 
     <style name="TextAppearance.ShowcaseView.Title" parent="android:style/TextAppearance.Large">

--- a/library/src/com/espian/showcaseview/OnShowcaseEventListener.java
+++ b/library/src/com/espian/showcaseview/OnShowcaseEventListener.java
@@ -7,6 +7,8 @@ public interface OnShowcaseEventListener {
 
     public void onShowcaseViewHide(ShowcaseView showcaseView);
 
+    public void onShowcaseViewHideOnInnerCircle(ShowcaseView showcaseView);
+
     public void onShowcaseViewDidHide(ShowcaseView showcaseView);
 
     public void onShowcaseViewShow(ShowcaseView showcaseView);
@@ -18,6 +20,11 @@ public interface OnShowcaseEventListener {
     public static final OnShowcaseEventListener NONE = new OnShowcaseEventListener() {
         @Override
         public void onShowcaseViewHide(ShowcaseView showcaseView) {
+
+        }
+
+        @Override
+        public void onShowcaseViewHideOnInnerCircle(ShowcaseView showcaseView) {
 
         }
 

--- a/library/src/com/espian/showcaseview/ShowcaseView.java
+++ b/library/src/com/espian/showcaseview/ShowcaseView.java
@@ -394,7 +394,7 @@ public class ShowcaseView extends RelativeLayout
         boolean recalculateText = recalculatedCling || mAlteredText;
         mAlteredText = false;
 
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.HONEYCOMB && !mHasNoTarget) {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.HONEYCOMB && !mHasNoTarget && !mOptions.removeShowcaseHighlight) {
         	Path path = new Path();
             path.addCircle(showcaseX, showcaseY, showcaseRadius, Path.Direction.CW);
             canvas.clipPath(path, Op.DIFFERENCE);
@@ -404,7 +404,7 @@ public class ShowcaseView extends RelativeLayout
         canvas.drawColor(mBackgroundColor);
 
         // Draw the showcase drawable
-        if (!mHasNoTarget) {
+        if (!mHasNoTarget && !mOptions.removeShowcaseHighlight) {
             mShowcaseDrawer.drawShowcase(canvas, showcaseX, showcaseY, scaleMultiplier, showcaseRadius);
         }
 
@@ -868,6 +868,8 @@ public class ShowcaseView extends RelativeLayout
         public boolean block = true, noButton = false;
         public boolean hideOnClickOutside = false;
         public boolean hideOnInnerCircleClick = false;
+
+        public boolean removeShowcaseHighlight = false;
 
         /**
          * Does not work with the {@link ShowcaseViews} class as it does not make sense (only with

--- a/library/src/com/espian/showcaseview/ShowcaseView.java
+++ b/library/src/com/espian/showcaseview/ShowcaseView.java
@@ -93,11 +93,11 @@ public class ShowcaseView extends RelativeLayout
 
     private boolean mHasNoTarget = false;
 
-    protected ShowcaseView(Context context) {
-        this(context, null, R.styleable.CustomTheme_showcaseViewStyle);
+    protected ShowcaseView(Context context, ConfigOptions options) {
+        this(context, null, R.styleable.CustomTheme_showcaseViewStyle, options);
     }
 
-    protected ShowcaseView(Context context, AttributeSet attrs, int defStyle) {
+    protected ShowcaseView(Context context, AttributeSet attrs, int defStyle, ConfigOptions options) {
         super(context, attrs, defStyle);
 
         // Get the attributes for the ShowcaseView
@@ -129,7 +129,10 @@ public class ShowcaseView extends RelativeLayout
         mTextDrawer.setTitleStyling(context, titleTextAppearance);
         mTextDrawer.setDetailStyling(context, detailTextAppearance);
 
-        ConfigOptions options = new ConfigOptions();
+        if(options == null) {
+            options = new ConfigOptions();
+        }
+
         options.showcaseId = getId();
         setConfigOptions(options);
 
@@ -637,7 +640,7 @@ public class ShowcaseView extends RelativeLayout
     public static ShowcaseView insertShowcaseView(View viewToShowcase, Activity activity,
             String title,
             String detailText, ConfigOptions options) {
-        ShowcaseView sv = new ShowcaseView(activity);
+        ShowcaseView sv = new ShowcaseView(activity, options);
         if (options != null) {
             sv.setConfigOptions(options);
         }
@@ -665,7 +668,7 @@ public class ShowcaseView extends RelativeLayout
     @Deprecated
     public static ShowcaseView insertShowcaseView(View viewToShowcase, Activity activity, int title,
             int detailText, ConfigOptions options) {
-        ShowcaseView sv = new ShowcaseView(activity);
+        ShowcaseView sv = new ShowcaseView(activity, options);
         if (options != null) {
             sv.setConfigOptions(options);
         }
@@ -711,7 +714,7 @@ public class ShowcaseView extends RelativeLayout
     @Deprecated
     public static ShowcaseView insertShowcaseView(int x, int y, Activity activity, String title,
             String detailText, ConfigOptions options) {
-        ShowcaseView sv = new ShowcaseView(activity);
+        ShowcaseView sv = new ShowcaseView(activity, options);
         if (options != null) {
             sv.setConfigOptions(options);
         }
@@ -731,7 +734,7 @@ public class ShowcaseView extends RelativeLayout
     @Deprecated
     public static ShowcaseView insertShowcaseView(int x, int y, Activity activity, int title,
             int detailText, ConfigOptions options) {
-        ShowcaseView sv = new ShowcaseView(activity);
+        ShowcaseView sv = new ShowcaseView(activity, options);
         if (options != null) {
             sv.setConfigOptions(options);
         }
@@ -769,7 +772,7 @@ public class ShowcaseView extends RelativeLayout
     @Deprecated
     public static ShowcaseView insertShowcaseViewWithType(int type, int itemId, Activity activity,
             String title, String detailText, ConfigOptions options) {
-        ShowcaseView sv = new ShowcaseView(activity);
+        ShowcaseView sv = new ShowcaseView(activity, options);
         if (options != null) {
             sv.setConfigOptions(options);
         }
@@ -798,7 +801,7 @@ public class ShowcaseView extends RelativeLayout
     @Deprecated
     public static ShowcaseView insertShowcaseViewWithType(int type, int itemId, Activity activity,
             int title, int detailText, ConfigOptions options) {
-        ShowcaseView sv = new ShowcaseView(activity);
+        ShowcaseView sv = new ShowcaseView(activity, options);
         if (options != null) {
             sv.setConfigOptions(options);
         }
@@ -822,7 +825,7 @@ public class ShowcaseView extends RelativeLayout
      */
     private static ShowcaseView insertShowcaseViewInternal(Target target, Activity activity, String title,
                                                            String detail, ConfigOptions options) {
-        ShowcaseView sv = new ShowcaseView(activity);
+        ShowcaseView sv = new ShowcaseView(activity, options);
         sv.setConfigOptions(options);
         if (sv.getConfigOptions().insert == INSERT_TO_DECOR) {
             ((ViewGroup) activity.getWindow().getDecorView()).addView(sv);

--- a/library/src/com/espian/showcaseview/ShowcaseView.java
+++ b/library/src/com/espian/showcaseview/ShowcaseView.java
@@ -530,11 +530,11 @@ public class ShowcaseView extends RelativeLayout
         if (MotionEvent.ACTION_UP == motionEvent.getAction()) {
 
             if(mOptions.hideOnInnerCircleClick && distanceFromFocus <= showcaseRadius) {
-                this.hide();
+                this.onClick(view);
                 mEventListener.onShowcaseViewHideOnInnerCircle(this);
                 return true;
             } else if(mOptions.hideOnClickOutside && distanceFromFocus > showcaseRadius ) {
-                this.hide();
+                this.onClick(view);
                 return true;
             }
         }

--- a/library/src/com/espian/showcaseview/ShowcaseView.java
+++ b/library/src/com/espian/showcaseview/ShowcaseView.java
@@ -243,6 +243,7 @@ public class ShowcaseView extends RelativeLayout
         postDelayed(new Runnable() {
             @Override
             public void run() {
+
                 Point targetPoint = target.getPoint();
                 if (targetPoint != null) {
                     mHasNoTarget = false;

--- a/library/src/com/espian/showcaseview/ShowcaseView.java
+++ b/library/src/com/espian/showcaseview/ShowcaseView.java
@@ -527,13 +527,19 @@ public class ShowcaseView extends RelativeLayout
         float yDelta = Math.abs(motionEvent.getRawY() - showcaseY);
         double distanceFromFocus = Math.sqrt(Math.pow(xDelta, 2) + Math.pow(yDelta, 2));
 
-        if (MotionEvent.ACTION_UP == motionEvent.getAction() &&
-            mOptions.hideOnClickOutside && distanceFromFocus > showcaseRadius) {
-            this.hide();
-            return true;
+        if (MotionEvent.ACTION_UP == motionEvent.getAction()) {
+
+            if(mOptions.hideOnInnerCircleClick && distanceFromFocus <= showcaseRadius) {
+                this.hide();
+                mEventListener.onShowcaseViewHideOnInnerCircle(this);
+                return true;
+            } else if(mOptions.hideOnClickOutside && distanceFromFocus > showcaseRadius ) {
+                this.hide();
+                return true;
+            }
         }
 
-        return mOptions.block && distanceFromFocus > showcaseRadius;
+        return mOptions.hideOnInnerCircleClick || (mOptions.block && distanceFromFocus > showcaseRadius);
     }
 
     /**
@@ -861,6 +867,7 @@ public class ShowcaseView extends RelativeLayout
 
         public boolean block = true, noButton = false;
         public boolean hideOnClickOutside = false;
+        public boolean hideOnInnerCircleClick = false;
 
         /**
          * Does not work with the {@link ShowcaseViews} class as it does not make sense (only with

--- a/library/src/com/espian/showcaseview/ShowcaseView.java
+++ b/library/src/com/espian/showcaseview/ShowcaseView.java
@@ -78,6 +78,7 @@ public class ShowcaseView extends RelativeLayout
     OnShowcaseEventListener mEventListener = OnShowcaseEventListener.NONE;
     private boolean mAlteredText = false;
 
+
     private final String buttonText;
 
     private float scaleMultiplier = 1f;
@@ -133,7 +134,7 @@ public class ShowcaseView extends RelativeLayout
             options = new ConfigOptions();
         }
 
-        options.showcaseId = getId();
+//        options.showcaseId = getId();
         setConfigOptions(options);
 
         init();
@@ -152,7 +153,7 @@ public class ShowcaseView extends RelativeLayout
             return;
         }
 
-        showcaseRadius = metricScale * INNER_CIRCLE_RADIUS;
+        showcaseRadius = metricScale * mOptions.showCaseRadius;
         setOnTouchListener(this);
 
         if (!mOptions.noButton && mEndButton.getParent() == null) {
@@ -870,6 +871,8 @@ public class ShowcaseView extends RelativeLayout
         public boolean hideOnInnerCircleClick = false;
 
         public boolean removeShowcaseHighlight = false;
+
+        public int showCaseRadius = 94;
 
         /**
          * Does not work with the {@link ShowcaseViews} class as it does not make sense (only with

--- a/library/src/com/espian/showcaseview/ShowcaseView.java
+++ b/library/src/com/espian/showcaseview/ShowcaseView.java
@@ -15,6 +15,7 @@ import android.graphics.Region.Op;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -117,11 +118,19 @@ public class ShowcaseView extends RelativeLayout
                 .getResourceId(R.styleable.ShowcaseView_sv_detailTextAppearance,
                         R.style.TextAppearance_ShowcaseView_Detail);
 
+
+        final TypedArray styledBtn = context.getTheme()
+                .obtainStyledAttributes(attrs, R.styleable.CustomTheme, R.attr.showcaseViewStyle,
+                        0);
+
         buttonText = styled.getString(R.styleable.ShowcaseView_sv_buttonText);
+
         styled.recycle();
 
         metricScale = getContext().getResources().getDisplayMetrics().density;
-        mEndButton = (Button) LayoutInflater.from(context).inflate(R.layout.showcase_button, null);
+        mEndButton = (Button) LayoutInflater.from(new ContextThemeWrapper(context, styledBtn.getResourceId(R.styleable.CustomTheme_showcaseViewStyle, R.style.ShowcaseView))).inflate(R.layout.showcase_button, null);
+
+        styledBtn.recycle();
 
         mShowcaseDrawer = new ClingDrawerImpl(getResources(), showcaseColor);
 
@@ -157,6 +166,7 @@ public class ShowcaseView extends RelativeLayout
         setOnTouchListener(this);
 
         if (!mOptions.noButton && mEndButton.getParent() == null) {
+
             RelativeLayout.LayoutParams lps = getConfigOptions().buttonLayoutParams;
             if (lps == null) {
                 lps = (LayoutParams) generateDefaultLayoutParams();

--- a/library/src/com/espian/showcaseview/ShowcaseViewBuilder.java
+++ b/library/src/com/espian/showcaseview/ShowcaseViewBuilder.java
@@ -8,7 +8,7 @@ public class ShowcaseViewBuilder {
     private final ShowcaseView showcaseView;
 
     public ShowcaseViewBuilder(Activity activity) {
-        this.showcaseView = new ShowcaseView(activity);
+        this.showcaseView = new ShowcaseView(activity, new ShowcaseView.ConfigOptions());
     }
 
     public ShowcaseViewBuilder(ShowcaseView showcaseView) {

--- a/library/src/com/espian/showcaseview/actionbar/reflection/ActionBarReflector.java
+++ b/library/src/com/espian/showcaseview/actionbar/reflection/ActionBarReflector.java
@@ -18,9 +18,19 @@ public class ActionBarReflector extends BaseReflector {
     public View getHomeButton() {
         View homeButton = mActivity.findViewById(android.R.id.home);
         if (homeButton == null) {
-            throw new RuntimeException(
+            int homeId = mActivity.getResources().getIdentifier("abs__home","id", mActivity.getPackageName());
+            if(homeId == 0) {
+                homeId = mActivity.getResources().getIdentifier("home","id", mActivity.getPackageName());
+            }
+            if(homeId != 0) {
+                homeButton = mActivity.findViewById(homeId);
+            }
+
+            if(homeButton == null) {
+                throw new RuntimeException(
                     "insertShowcaseViewWithType cannot be used when the theme " +
                             "has no ActionBar");
+            }
         }
         return homeButton;
     }

--- a/library/src/com/espian/showcaseview/drawing/TextDrawerImpl.java
+++ b/library/src/com/espian/showcaseview/drawing/TextDrawerImpl.java
@@ -111,7 +111,7 @@ public class TextDrawerImpl implements TextDrawer {
     	int[] areas = new int[4]; //left, top, right, bottom
     	areas[0] = showcase.left * canvasH;
     	areas[1] = showcase.top * canvasW;
-    	areas[2] = (canvasW - showcase.right) * canvasH;
+    	areas[2] = (canvasW - showcase.right) * canvasH / 2;
     	areas[3] = (canvasH - showcase.bottom) * canvasW;
     	
     	int largest = 0;

--- a/library/src/com/espian/showcaseview/targets/ViewTarget.java
+++ b/library/src/com/espian/showcaseview/targets/ViewTarget.java
@@ -2,6 +2,7 @@ package com.espian.showcaseview.targets;
 
 import android.app.Activity;
 import android.graphics.Point;
+import android.util.Log;
 import android.view.View;
 
 public class ViewTarget implements Target {
@@ -18,10 +19,16 @@ public class ViewTarget implements Target {
 
     @Override
     public Point getPoint() {
-        int[] location = new int[2];
-        mView.getLocationInWindow(location);
-        int x = location[0] + mView.getWidth() / 2;
-        int y = location[1] + mView.getHeight() / 2;
-        return new Point(x, y);
+        try {
+            int[] location = new int[2];
+            mView.getLocationInWindow(location);
+            int x = location[0] + mView.getWidth() / 2;
+            int y = location[1] + mView.getHeight() / 2;
+
+            return new Point(x, y);
+        } catch (NullPointerException e) {
+            Log.d("ShowCaseView", "Could not identify Target ");
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Hey there i just fixed that the options are used when the ShowcaseView is initialized, because my TYPE_ONE_SHOT where shown every time. I Also added an option to hide on an inner circle click, also for this i added an listener for the innercircle click. Reason for this was the case when i want a user to do the action and close the Showcase while doing an action.