### PR TITLE
Allowing to use SherlockFragmentActivity instead of just SherlockActivity

### DIFF
--- a/library/src/com/espian/showcaseview/actionbar/reflection/BaseReflector.java
+++ b/library/src/com/espian/showcaseview/actionbar/reflection/BaseReflector.java
@@ -32,7 +32,7 @@ public abstract class BaseReflector {
     private static ActionBarType searchForActivitySuperClass(Activity activity) {
         Class currentLevel = activity.getClass();
         while (currentLevel != Activity.class) {
-            if (currentLevel.getSimpleName().equals("SherlockActivity")) {
+            if (currentLevel.getSimpleName().equals("SherlockActivity") || currentLevel.getSimpleName().equals("SherlockFragmentActivity")) {
                 return ActionBarType.ACTIONBAR_SHERLOCK;
             }
             if (currentLevel.getSimpleName().equals("ActionBarActivity")) {


### PR DESCRIPTION
Fix the exception thrown when the activity passed to `ShowcaseView` is an instance of `SherlockFragmentActivity`.
