### PR TITLE
Added ActionTabTarget to allow using actionbar tabs as a targets.

### DIFF
--- a/library/src/com/espian/showcaseview/actionbar/ActionBarViewWrapper.java
+++ b/library/src/com/espian/showcaseview/actionbar/ActionBarViewWrapper.java
@@ -1,10 +1,11 @@
 package com.espian.showcaseview.actionbar;
 
+import java.lang.reflect.Field;
+
 import android.util.Log;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewParent;
-
-import java.lang.reflect.Field;
 
 /**
  * Class which wraps round the many implementations of ActionBarView and allows finding of Action
@@ -82,6 +83,37 @@ public class ActionBarViewWrapper {
         return null;
     }
 
+    public View getTabItem(int tabId) {
+    	try {
+    		
+            // first we assume that it's in portrait moe
+        	Field tabViewField = mActionBarView.getParent().getClass().getDeclaredField("mTabContainer");
+        	tabViewField.setAccessible(true);
+            Object tabView = tabViewField.get(mActionBarView.getParent());
+            
+            // if tabView is not on parent mTabContainer field
+            if (tabView == null) {
+            	// it's in landscape mode, so me search on mTabScrollView field
+            	tabViewField = mActionBarView.getClass().getDeclaredField("mTabScrollView");
+            	tabViewField.setAccessible(true);
+                tabView = tabViewField.get(mActionBarView);
+            }
+            
+            Field tabLayoutField = tabView.getClass().getDeclaredField("mTabLayout");
+            tabLayoutField.setAccessible(true);
+            ViewGroup tabLayout = (ViewGroup) tabLayoutField.get(tabView);
+            	
+            View view = tabLayout.getChildAt(tabId);
+        	return view;
+        	
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (NoSuchFieldException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+    
     public View getActionItem(int actionItemId) {
         try {
             Field actionMenuPresenterField = mAbsActionBarViewClass.getDeclaredField("mActionMenuPresenter");

--- a/library/src/com/espian/showcaseview/targets/ActionTabTarget.java
+++ b/library/src/com/espian/showcaseview/targets/ActionTabTarget.java
@@ -1,0 +1,37 @@
+package com.espian.showcaseview.targets;
+
+import android.app.Activity;
+import android.graphics.Point;
+import android.view.ViewParent;
+
+import com.actionbarsherlock.app.ActionBar;
+import com.actionbarsherlock.app.SherlockFragmentActivity;
+import com.espian.showcaseview.actionbar.ActionBarViewWrapper;
+import com.espian.showcaseview.actionbar.reflection.BaseReflector;
+
+public class ActionTabTarget implements Target {
+
+    private final Activity mActivity;
+    private final int tabId;
+
+    ActionBarViewWrapper mActionBarWrapper;
+
+    public ActionTabTarget(Activity activity, int tabId) {
+        mActivity = activity;
+		this.tabId = tabId;
+    }
+
+    @Override
+    public Point getPoint() {
+        setUp();
+        return new ViewTarget(mActionBarWrapper.getTabItem(tabId)).getPoint();
+    }
+
+    protected void setUp() {
+    	
+        BaseReflector reflector = BaseReflector.getReflectorForActivity(mActivity);
+        ViewParent p = reflector.getActionBarView(); //ActionBarView
+        mActionBarWrapper = new ActionBarViewWrapper(p);
+    }
+
+}


### PR DESCRIPTION
Allows to target a tab of the Actionbar as follows:  `ActionTabTarget target = new ActionTabTarget(activity, tabIndex);`
Tested on Android 2.3.6 (nexus one) and 4.4 versions (nexus 4).
I didn't test on a project not using Actionbar Sherlock and android support library.