### PR TITLE
Fixed bug in cling drawing, that cling was not redrawn correctly

### DIFF
--- a/library/src/com/espian/showcaseview/drawing/ClingDrawerImpl.java
+++ b/library/src/com/espian/showcaseview/drawing/ClingDrawerImpl.java
@@ -76,7 +76,7 @@ public class ClingDrawerImpl implements ClingDrawer {
         int dw = getShowcaseWidth();
         int dh = getShowcaseHeight();
 
-        if (mShowcaseRect.left == cx - dw / 2) {
+        if (mShowcaseRect.left == cx - dw / 2 && mShowcaseRect.top == cy - dh / 2) {
             return false;
         }
 


### PR DESCRIPTION
Fixed bug in cling drawing, that cling was not redrawn correctly, when the showcase just moved on the Y-Axis and not on the X-Axis
