### PR TITLE
Re-add setScaleMultiplier() method.

### DIFF
--- a/library/src/main/java/com/github/amlcurran/showcaseview/NewShowcaseDrawer.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/NewShowcaseDrawer.java
@@ -25,27 +25,27 @@ class NewShowcaseDrawer extends StandardShowcaseDrawer {
     }
 
     @Override
-    public void drawShowcase(Bitmap buffer, float x, float y, float scaleMultiplier) {
+    public void drawShowcase(Bitmap buffer, float x, float y) {
         Canvas bufferCanvas = new Canvas(buffer);
         eraserPaint.setAlpha(ALPHA_60_PERCENT);
-        bufferCanvas.drawCircle(x, y, outerRadius, eraserPaint);
+        bufferCanvas.drawCircle(x, y, outerRadius * scaleMultiplier, eraserPaint);
         eraserPaint.setAlpha(0);
-        bufferCanvas.drawCircle(x, y, innerRadius, eraserPaint);
+        bufferCanvas.drawCircle(x, y, innerRadius * scaleMultiplier, eraserPaint);
     }
 
     @Override
     public int getShowcaseWidth() {
-        return (int) (outerRadius * 2);
+        return (int) (outerRadius * scaleMultiplier * 2);
     }
 
     @Override
     public int getShowcaseHeight() {
-        return (int) (outerRadius * 2);
+        return (int) (outerRadius * scaleMultiplier * 2);
     }
 
     @Override
     public float getBlockedRadius() {
-        return innerRadius;
+        return innerRadius * scaleMultiplier;
     }
 
     @Override

--- a/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseDrawer.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseDrawer.java
@@ -10,7 +10,9 @@ interface ShowcaseDrawer {
 
     void setShowcaseColour(int color);
 
-    void drawShowcase(Bitmap buffer, float x, float y, float scaleMultiplier);
+    void setScaleMultiplier(float scaleMultiplier);
+
+    void drawShowcase(Bitmap buffer, float x, float y);
 
     int getShowcaseWidth();
 

--- a/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
@@ -41,7 +41,6 @@ public class ShowcaseView extends RelativeLayout
     // Showcase metrics
     private int showcaseX = -1;
     private int showcaseY = -1;
-    private float scaleMultiplier = 1f;
 
     // Touch items
     private boolean hasCustomClickListener = false;
@@ -247,7 +246,7 @@ public class ShowcaseView extends RelativeLayout
 
         // Draw the showcase drawable
         if (!hasNoTarget) {
-            showcaseDrawer.drawShowcase(bitmapBuffer, showcaseX, showcaseY, scaleMultiplier);
+            showcaseDrawer.drawShowcase(bitmapBuffer, showcaseX, showcaseY);
             showcaseDrawer.drawToCanvas(canvas, bitmapBuffer);
         }
 
@@ -334,7 +333,7 @@ public class ShowcaseView extends RelativeLayout
     }
 
     private void setScaleMultiplier(float scaleMultiplier) {
-        this.scaleMultiplier = scaleMultiplier;
+        showcaseDrawer.setScaleMultiplier(scaleMultiplier);
     }
 
     @Override
@@ -471,6 +470,11 @@ public class ShowcaseView extends RelativeLayout
          */
         public Builder singleShot(long shotId) {
             showcaseView.setSingleShot(shotId);
+            return this;
+        }
+
+        public Builder setScaleMultiplier(float scaleMultiplier) {
+            showcaseView.setScaleMultiplier(scaleMultiplier);
             return this;
         }
 

--- a/library/src/main/java/com/github/amlcurran/showcaseview/StandardShowcaseDrawer.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/StandardShowcaseDrawer.java
@@ -3,6 +3,7 @@ package com.github.amlcurran.showcaseview;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
@@ -18,6 +19,7 @@ class StandardShowcaseDrawer implements ShowcaseDrawer {
     private final Paint basicPaint;
     private final float showcaseRadius;
     protected int backgroundColour;
+    protected float scaleMultiplier = 1F;
 
     public StandardShowcaseDrawer(Resources resources) {
         PorterDuffXfermode xfermode = new PorterDuffXfermode(PorterDuff.Mode.MULTIPLY);
@@ -37,32 +39,40 @@ class StandardShowcaseDrawer implements ShowcaseDrawer {
     }
 
     @Override
-    public void drawShowcase(Bitmap buffer, float x, float y, float scaleMultiplier) {
+    public void setScaleMultiplier(float scaleMultiplier) {
+        this.scaleMultiplier = scaleMultiplier;
+    }
+
+    @Override
+    public void drawShowcase(Bitmap buffer, float x, float y) {
         Canvas bufferCanvas = new Canvas(buffer);
+
+        Matrix matrix = new Matrix();
+        matrix.postScale(scaleMultiplier, scaleMultiplier, x, y);
+        bufferCanvas.setMatrix(matrix);
+
         bufferCanvas.drawCircle(x, y, showcaseRadius, eraserPaint);
-        int halfW = getShowcaseWidth() / 2;
-        int halfH = getShowcaseHeight() / 2;
+        int halfW = showcaseDrawable.getIntrinsicWidth() / 2;
+        int halfH = showcaseDrawable.getIntrinsicHeight() / 2;
         int left = (int) (x - halfW);
         int top = (int) (y - halfH);
-        showcaseDrawable.setBounds(left, top,
-                left + getShowcaseWidth(),
-                top + getShowcaseHeight());
+        showcaseDrawable.setBounds(left, top, left + 2 * halfW, top + 2 * halfH);
         showcaseDrawable.draw(bufferCanvas);
     }
 
     @Override
     public int getShowcaseWidth() {
-        return showcaseDrawable.getIntrinsicWidth();
+        return (int) (scaleMultiplier * showcaseDrawable.getIntrinsicWidth());
     }
 
     @Override
     public int getShowcaseHeight() {
-        return showcaseDrawable.getIntrinsicHeight();
+        return (int) (scaleMultiplier * showcaseDrawable.getIntrinsicHeight());
     }
 
     @Override
     public float getBlockedRadius() {
-        return showcaseRadius;
+        return showcaseRadius * scaleMultiplier;
     }
 
     @Override


### PR DESCRIPTION
This can be used to highlight smaller targets, such as icons on
specific buttons. In order to make the method more useful, account for
the scale when calculating blockout areas.