### PR TITLE
Fix hasShowcaseView() method in case there is no target set

### DIFF
--- a/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
@@ -176,7 +176,7 @@ public class ShowcaseView extends RelativeLayout
     }
 
     public boolean hasShowcaseView() {
-        return (showcaseX != 1000000 && showcaseY != 1000000) || !hasNoTarget;
+        return (showcaseX != 1000000 && showcaseY != 1000000) && !hasNoTarget;
     }
 
     public void setShowcaseX(int x) {


### PR DESCRIPTION
Without this patch, the method will return true if the target is set to Target.NONE. In
this case showcaseX and showcaseY is set to -1 and hasNoTarget is set to true. Since
the method is used by the TextDrawer class, the text bounds were incorrect without
a target.
