### PR TITLE
Store shot state on touch hide

### DIFF
--- a/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
@@ -313,6 +313,7 @@ public class ShowcaseView extends RelativeLayout
 
         if (MotionEvent.ACTION_UP == motionEvent.getAction() &&
                 hideOnTouch && distanceFromFocus > showcaseDrawer.getBlockedRadius()) {
+            shotStateStore.storeShot();
             this.hide();
             return true;
         }


### PR DESCRIPTION
If hide on touch is enabled, it seems to me that the shot state should be stored when
hiding, just like in onClick. This change adds that.
