### PR TITLE
Adding the capability to include MediaRouteButton as an ActionViewTarget

### DIFF
--- a/library/src/main/java/com/github/amlcurran/showcaseview/targets/ActionBarViewWrapper.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/targets/ActionBarViewWrapper.java
@@ -81,6 +81,28 @@ class ActionBarViewWrapper {
         }
         return null;
     }
+    
+    /**
+     * Return the view which represents the MediaRouterButton action item on the ActionBar, or null
+     * if there isn't one
+     */
+    public View getMediaRouterButtonView() {
+        try {
+            Field actionMenuPresenterField =
+                    mAbsActionBarViewClass.getDeclaredField("mActionMenuPresenter");
+            actionMenuPresenterField.setAccessible(true);
+            Object actionMenuPresenter = actionMenuPresenterField.get(mActionBarView);
+            Field mediaRouteButtonField = actionMenuPresenter.getClass()
+                    .getDeclaredField("mScrapActionButtonView");
+            mediaRouteButtonField.setAccessible(true);
+            return (View) mediaRouteButtonField.get(actionMenuPresenter);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (NoSuchFieldException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
 
     public View getActionItem(int actionItemId) {
         try {

--- a/library/src/main/java/com/github/amlcurran/showcaseview/targets/ActionViewTarget.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/targets/ActionViewTarget.java
@@ -44,12 +44,16 @@ public class ActionViewTarget implements Target {
             case TITLE:
                 internal = new ViewTarget(mActionBarWrapper.getTitleView());
                 break;
+                
+            case MEDIA_ROUTE_BUTTON:
+                internal = new ViewTarget(mActionBarWrapper.getMediaRouterButtonView());
+                break;
 
         }
         return internal.getPoint();
     }
 
     public enum Type {
-        SPINNER, HOME, TITLE, OVERFLOW
+        SPINNER, HOME, TITLE, OVERFLOW, MEDIA_ROUTE_BUTTON
     }
 }


### PR DESCRIPTION
Hi.

In Google Cast design documentation (https://developers.google.com/cast/docs/design_checklist#prompting), it is recommended to provide a Cling type view to introduce the Cast button. This pull request adds the capability to your library to recognize the Cast button (MediaRouteButton) as an ActionViewTarget; a new Type is added and a simple usage would be:

```
    new ShowcaseView.Builder(this)
            .setTarget(new ActionViewTarget(this, ActionViewTarget.Type.MEDIA_ROUTE_BUTTON))
            .setContentTitle("Cast Title")
            .setContentText("Cast Text")
            .build();
```

If this can be added to the main library, it makes it easier for developers to use the library directly (preferred approach) rather than using my fork.

Many tanks
Ali.
