### PR TITLE
Fixed error java.lang.OutOfMemoryError

### DIFF
--- a/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
@@ -166,7 +166,10 @@ public class ShowcaseView extends RelativeLayout
 
     private void updateBitmap() {
         if (bitmapBuffer == null || haveBoundsChanged()) {
+            if(bitmapBuffer != null)
+        		bitmapBuffer.recycle();
             bitmapBuffer = Bitmap.createBitmap(getMeasuredWidth(), getMeasuredHeight(), Bitmap.Config.ARGB_8888);
+
         }
     }
 


### PR DESCRIPTION
Fixed error java.lang.OutOfMemoryError when the function updateBitmap() was called.
