### PR TITLE
Returning Target.NONE.getPoint() in case if actionItem is null

### DIFF
--- a/library/src/main/java/com/github/amlcurran/showcaseview/targets/ActionItemTarget.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/targets/ActionItemTarget.java
@@ -25,7 +25,11 @@ public class ActionItemTarget implements Target {
     @Override
     public Point getPoint() {
         setUp();
-        return new ViewTarget(mActionBarWrapper.getActionItem(mItemId)).getPoint();
+        View actionItem = mActionBarWrapper.getActionItem(mItemId);
+        if (actionItem == null) {
+            return Target.NONE.getPoint();
+        }
+        return new ViewTarget(actionItem).getPoint();
     }
 
     protected void setUp() {


### PR DESCRIPTION
 This fix is for preventing NPE when trying to target a hidden ActionBar Item #195 
Added a check for actionItem, if it is null returning the point of Target.NONE