### PR TITLE
Add missing XML namespace information in resources

### DIFF
--- a/library/src/main/res/layout/showcase_button.xml
+++ b/library/src/main/res/layout/showcase_button.xml
@@ -17,5 +17,5 @@
 
 <Button xmlns:android="http://schemas.android.com/apk/res/android"
     style="@style/ShowcaseButton"
-    android:text="@string/ok"
+    android:text="@android:string/ok"
     android:id="@id/showcase_button" />

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   -->
 
-<resources>
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
 
     <style name="ShowcaseButton">
         <item name="android:layout_width">wrap_content</item>
@@ -30,14 +30,14 @@
         <item name="sv_titleTextAppearance">@style/TextAppearance.ShowcaseView.Title</item>
         <item name="sv_detailTextAppearance">@style/TextAppearance.ShowcaseView.Detail.Light</item>
         <item name="sv_backgroundColor">#3333B5E5</item>
-        <item name="sv_buttonText">@string/ok</item>
+        <item name="sv_buttonText">@android:string/ok</item>
     </style>
 
     <style name="ShowcaseView">
         <item name="sv_titleTextAppearance">@style/TextAppearance.ShowcaseView.Title</item>
         <item name="sv_detailTextAppearance">@style/TextAppearance.ShowcaseView.Detail</item>
         <item name="sv_backgroundColor">#3333B5E5</item>
-        <item name="sv_buttonText">@string/ok</item>
+        <item name="sv_buttonText">@android:string/ok</item>
     </style>
 
     <style name="TextAppearance.ShowcaseView.Title" parent="android:style/TextAppearance.Large">


### PR DESCRIPTION
Some XML namespace information is missing. While some tools tolerate it because they know it is being built for Android, some (such as recent versions of Intellij IDEA / Android Studio) do not like it at all and properly flag those omissions as errors.
