### PR TITLE
Set the base, inner and outer Radius over every call

### DIFF
--- a/library/src/main/java/com/github/amlcurran/showcaseview/NewShowcaseDrawer.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/NewShowcaseDrawer.java
@@ -26,13 +26,25 @@ import android.graphics.Canvas;
 class NewShowcaseDrawer extends StandardShowcaseDrawer {
 
     private static final int ALPHA_60_PERCENT = 153;
-    private final float outerRadius;
-    private final float innerRadius;
+    
+    // Probably i'm dumb as fuck, but i dont really know why we need this final
+    //private final float outerRadius;
+    //private final float innerRadius;
+    private float outerRadius;
+    private float innerRadius;
 
     public NewShowcaseDrawer(Resources resources) {
         super(resources);
         outerRadius = resources.getDimension(R.dimen.showcase_radius_outer);
         innerRadius = resources.getDimension(R.dimen.showcase_radius_inner);
+    }
+    
+    public void setInnerRadius(float innerRadius){
+        this.innerRadius = innerRadius;
+    }
+    
+    public void setOuterRadius(float outerRadius){
+        this.outerRadius = outerRadius;
     }
 
     @Override
@@ -42,6 +54,21 @@ class NewShowcaseDrawer extends StandardShowcaseDrawer {
 
     @Override
     public void drawShowcase(Bitmap buffer, float x, float y, float scaleMultiplier) {
+        Canvas bufferCanvas = new Canvas(buffer);
+        eraserPaint.setAlpha(ALPHA_60_PERCENT);
+        bufferCanvas.drawCircle(x, y, this.outerRadius, eraserPaint);
+        eraserPaint.setAlpha(0);
+        bufferCanvas.drawCircle(x, y, this.innerRadius, eraserPaint);
+    }
+
+    // If it's really necessary to maintain inner/outer radius as finals so we can get a flexible radius over here
+    // which i judge (without any doc) it's the function that matters
+    // the problem is the getters of BlockedRadius and Showcase width/height! they both acces the inner/outer radius so
+    // it's better to make those fields not finals.
+    @Override
+    public void drawShowcase(Bitmap buffer, float x, float y, float innerRadius, float outerRadius, float scaleMultiplier) {
+        this.innerRadius = innerRadius; // make sure getShowcase method will work well
+        this.outerRadius = outerRadius; // make sure getBlockedRadius show well
         Canvas bufferCanvas = new Canvas(buffer);
         eraserPaint.setAlpha(ALPHA_60_PERCENT);
         bufferCanvas.drawCircle(x, y, outerRadius, eraserPaint);

--- a/library/src/main/java/com/github/amlcurran/showcaseview/NewShowcaseDrawer.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/NewShowcaseDrawer.java
@@ -30,8 +30,8 @@ class NewShowcaseDrawer extends StandardShowcaseDrawer {
     // Probably i'm dumb as fuck, but i dont really know why we need this final
     //private final float outerRadius;
     //private final float innerRadius;
-    private float outerRadius;
-    private float innerRadius;
+    public float outerRadius;
+    public float innerRadius;
 
     public NewShowcaseDrawer(Resources resources) {
         super(resources);
@@ -42,9 +42,19 @@ class NewShowcaseDrawer extends StandardShowcaseDrawer {
     public void setInnerRadius(float innerRadius){
         this.innerRadius = innerRadius;
     }
-    
+
+    public float getInnerRadius() {
+
+        return innerRadius;
+    }
+
     public void setOuterRadius(float outerRadius){
         this.outerRadius = outerRadius;
+    }
+
+    public float getOuterRadius() {
+
+        return outerRadius;
     }
 
     @Override
@@ -71,24 +81,42 @@ class NewShowcaseDrawer extends StandardShowcaseDrawer {
         this.outerRadius = outerRadius; // make sure getBlockedRadius show well
         Canvas bufferCanvas = new Canvas(buffer);
         eraserPaint.setAlpha(ALPHA_60_PERCENT);
-        bufferCanvas.drawCircle(x, y, outerRadius, eraserPaint);
+        //bufferCanvas.drawCircle(x, y, outerRadius, eraserPaint);
+        bufferCanvas.drawCircle(x, y, this.getOuterRadius(), eraserPaint);
         eraserPaint.setAlpha(0);
-        bufferCanvas.drawCircle(x, y, innerRadius, eraserPaint);
+        //bufferCanvas.drawCircle(x, y, innerRadius, eraserPaint);
+        bufferCanvas.drawCircle(x, y, this.getInnerRadius(), eraserPaint);
     }
 
+
+    /*
     @Override
     public int getShowcaseWidth() {
         return (int) (outerRadius * 2);
+    }*/
+    @Override
+    public int getShowcaseWidth() {
+        return (int) (this.getOuterRadius() * 2);
     }
+
+    /*@Override
+    public int getShowcaseHeight() {
+        return (int) (outerRadius * 2);
+    }*/
 
     @Override
     public int getShowcaseHeight() {
-        return (int) (outerRadius * 2);
+        return (int) (this.outerRadius * 2);
     }
+
+    /*@Override
+    public float getBlockedRadius() {
+        return innerRadius;
+    }*/
 
     @Override
     public float getBlockedRadius() {
-        return innerRadius;
+        return this.getInnerRadius();
     }
 
     @Override

--- a/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseDrawer.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseDrawer.java
@@ -24,10 +24,22 @@ import android.graphics.Canvas;
  */
 interface ShowcaseDrawer {
 
+    public void setShowcaseRadius(float showcaseRadius);
+
+    public float getShowcaseRadius();
+
+    public void setInnerRadius(float innerRadius);
+
+    public float getInnerRadius();
+
+    public void setOuterRadius(float outerRadius);
+
+    public float getOuterRadius();
+
     void setShowcaseColour(int color);
 
     void drawShowcase(Bitmap buffer, float x, float y, float scaleMultiplier);
-    
+
     void drawShowcase(Bitmap buffer, float x, float y, float innerRadius, float outerRadius, float scaleMultiplier);
 
     int getShowcaseWidth();

--- a/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseDrawer.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseDrawer.java
@@ -27,6 +27,8 @@ interface ShowcaseDrawer {
     void setShowcaseColour(int color);
 
     void drawShowcase(Bitmap buffer, float x, float y, float scaleMultiplier);
+    
+    void drawShowcase(Bitmap buffer, float x, float y, float innerRadius, float outerRadius, float scaleMultiplier);
 
     int getShowcaseWidth();
 

--- a/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
@@ -75,10 +75,33 @@ public class ShowcaseView extends RelativeLayout
     private long fadeOutMillis;
     private boolean isShowing;
 
+    public void setInnerRadius(float innerRadius){
+
+        showcaseDrawer.setInnerRadius(innerRadius);
+    }
+
+    public void setOuterRadius(float outerRadius){
+
+        showcaseDrawer.setOuterRadius(outerRadius);
+    }
+
+    public void setRadius(float showcaseRadius){
+        showcaseDrawer.setShowcaseRadius(showcaseRadius);
+    }
+
+    public void setAllRadius(float radius, float innerRadius, float outerRadius){
+        this.showcaseDrawer.setShowcaseRadius(radius);
+        this.showcaseDrawer.setInnerRadius(innerRadius);
+        this.showcaseDrawer.setOuterRadius(outerRadius);
+    }
+
+    // what 01? The problem is why this extra constructor? man stop using resource! use style for god's sake!
+    // stop believing google knows what is good to android just because he bought the project!
     protected ShowcaseView(Context context, boolean newStyle) {
         this(context, null, R.styleable.CustomTheme_showcaseViewStyle, newStyle);
     }
 
+    // what 02?
     protected ShowcaseView(Context context, AttributeSet attrs, int defStyle, boolean newStyle) {
         super(context, attrs, defStyle);
 
@@ -101,6 +124,7 @@ public class ShowcaseView extends RelativeLayout
         fadeOutMillis = getResources().getInteger(android.R.integer.config_mediumAnimTime);
 
         mEndButton = (Button) LayoutInflater.from(context).inflate(R.layout.showcase_button, null);
+
         if (newStyle) {
             showcaseDrawer = new NewShowcaseDrawer(getResources());
         } else {
@@ -395,6 +419,28 @@ public class ShowcaseView extends RelativeLayout
             this.activity = activity;
             this.showcaseView = new ShowcaseView(activity, useNewStyle);
             this.showcaseView.setTarget(Target.NONE);
+        }
+
+        public Builder setRadius(float radius){
+            this.showcaseView.setRadius(radius);
+            return this;
+        }
+
+        public Builder setInnerRadius(float innerRadius){
+            this.showcaseView.setInnerRadius(innerRadius);
+            return this;
+        }
+
+        public Builder setOuterRadius(float outerRadius){
+            this.showcaseView.setOuterRadius(outerRadius);
+            return this;
+        }
+
+        public Builder setAllRadius(float radius, float innerRadius, float outerRadius){
+            this.showcaseView.setRadius(radius);
+            this.showcaseView.setInnerRadius(innerRadius);
+            this.showcaseView.setOuterRadius(outerRadius);
+            return this;
         }
 
         /**

--- a/library/src/main/java/com/github/amlcurran/showcaseview/StandardShowcaseDrawer.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/StandardShowcaseDrawer.java
@@ -62,6 +62,11 @@ class StandardShowcaseDrawer implements ShowcaseDrawer {
                 top + getShowcaseHeight());
         showcaseDrawable.draw(bufferCanvas);
     }
+    
+    @Override
+    public void drawShowcase(Bitmap buffer, float x, float y, float innerRadius, float outerRadius, float scaleMultiplier ) {
+        // pass
+    } 
 
     @Override
     public int getShowcaseWidth() {

--- a/library/src/main/java/com/github/amlcurran/showcaseview/StandardShowcaseDrawer.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/StandardShowcaseDrawer.java
@@ -29,8 +29,38 @@ class StandardShowcaseDrawer implements ShowcaseDrawer {
     protected final Paint eraserPaint;
     protected final Drawable showcaseDrawable;
     private final Paint basicPaint;
-    private final float showcaseRadius;
+    // Why final dude! why .-. and why private? this is not a playground for kids, we are adults here?
+    private float showcaseRadius;
     protected int backgroundColour;
+
+    // - now we gonna need this to "jump over" the proof-kid fence -.-
+    public float getShowcaseRadius() {
+
+        return showcaseRadius;
+    }
+
+    @Override public void setInnerRadius(float innerRadius) {
+
+    }
+
+    @Override public float getInnerRadius() {
+
+        return 0;
+    }
+
+    @Override public void setOuterRadius(float outerRadius) {
+
+    }
+
+    @Override public float getOuterRadius() {
+
+        return 0;
+    }
+
+    public void setShowcaseRadius(float showcaseRadius) {
+
+        this.showcaseRadius = showcaseRadius;
+    }
 
     public StandardShowcaseDrawer(Resources resources) {
         PorterDuffXfermode xfermode = new PorterDuffXfermode(PorterDuff.Mode.MULTIPLY);
@@ -52,7 +82,8 @@ class StandardShowcaseDrawer implements ShowcaseDrawer {
     @Override
     public void drawShowcase(Bitmap buffer, float x, float y, float scaleMultiplier) {
         Canvas bufferCanvas = new Canvas(buffer);
-        bufferCanvas.drawCircle(x, y, showcaseRadius, eraserPaint);
+        //bufferCanvas.drawCircle(x, y, showcaseRadius, eraserPaint);
+        bufferCanvas.drawCircle(x, y, this.getShowcaseRadius(), eraserPaint);
         int halfW = getShowcaseWidth() / 2;
         int halfH = getShowcaseHeight() / 2;
         int left = (int) (x - halfW);

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -14,6 +14,13 @@
   ~ limitations under the License.
   -->
 
+<!-- Why the hell the project is not using style to setup the radiu?
+    the style is the only (xml/canonical) way to set configuration of a 
+    widget with multiple version! Since there is zero efforts to make
+    available a simples set method to change radius, so it's more flexible
+    extract overhere the radius values? no? well i'm sorry
+-->
+
 <resources>
 
     <declare-styleable name="ShowcaseView">
@@ -27,6 +34,11 @@
         <attr name="sv_titleTextAppearance" format="reference" />
         <attr name="sv_showcaseColor" format="color|reference" />
         <attr name="sv_tintButtonColor" format="boolean|reference" />
+        
+        <attr name="sv_radius" format="dimension" />
+        <attr name="sv_radius_inner" format="dimension" />
+        <attr name="sv_radius_outter" format="dimension" />
+        
     </declare-styleable>
     <declare-styleable name="CustomTheme">
         <attr name="showcaseViewStyle" format="reference" />

--- a/sample/src/main/java/com/github/amlcurran/showcaseview/sample/SampleActivity.java
+++ b/sample/src/main/java/com/github/amlcurran/showcaseview/sample/SampleActivity.java
@@ -75,6 +75,7 @@ public class SampleActivity extends Activity implements View.OnClickListener,
                 .setContentText(R.string.showcase_main_message)
                 .setStyle(R.style.CustomShowcaseTheme2)
                 .setShowcaseEventListener(this)
+                .setAllRadius(30,40,50)
                 .build();
         sv.setButtonPosition(lps);
     }

--- a/sample/src/main/java/com/github/amlcurran/showcaseview/sample/animations/AnimationSampleActivity.java
+++ b/sample/src/main/java/com/github/amlcurran/showcaseview/sample/animations/AnimationSampleActivity.java
@@ -68,15 +68,18 @@ public class AnimationSampleActivity extends Activity implements View.OnClickLis
     public void onClick(View v) {
         switch (counter) {
             case 0:
+                showcaseView.setAllRadius(60,70,80);
                 showcaseView.setShowcase(new ViewTarget(textView2), true);
                 break;
 
             case 1:
+                showcaseView.setAllRadius(10,20,30);
                 showcaseView.setShowcase(new ViewTarget(textView3), true);
                 break;
 
             case 2:
                 showcaseView.setTarget(Target.NONE);
+                showcaseView.setAllRadius(40,50,60);
                 showcaseView.setContentTitle("Check it out");
                 showcaseView.setContentText("You don't always need a target to showcase");
                 showcaseView.setButtonText(getString(R.string.close));


### PR DESCRIPTION
Guys! This pull request is not intent to be acceptable at all. For you guys i probably "messed up" the code.
The important here is the new methods signatures over the interface __ShowcaseDrawer__ i just forced the implementation of getter/setters over the _showcaseRadius_ and the future/possible inner/outer Radius variables which is not user at all over the __StandardShowcaseDrawer__ but will be on the __NewShowcaseDrawer__.

The great problem is that the original intent of project is to make sure we are using all the widget on the screen with the same width. This is not cool at all. Google recommends to use dimens but it's just another hard-coded allowed ~~not useful at all~~ resource. We can solve this issue rewriting the constructors that are based only on dimens.xml. But i dont have time to redo all this thing. So the fast solution here is to make base __interface__ force the contract with getters/setters for the radius so we can use it on the __ShowcaseView__ without more problems.

You guys will see over the __StandardShowcaseDrawer__ the new signatures doesn't even make sense. That's right, but in my case i'm not using this, and on the future update this Standard thing should be removed with power of a one Only class based on the style.xml

And of course as a regular python developer i cannot avoid bitching about your "child's fence" over the variables. AFAIK this is not a playground for kids.

thanks for the project. it's an amazing working code, but you guys didn't realize one thing: ignore google's advice and focus on the user of the styles.xml not dimens.xml.

As i said. don't accept this pull at all because there are modifications on the code you guys will not like, but focus on reading the new signatures over the interface and the new methods over the Builder class too.