### PR TITLE
Update Readme with 5.3.0 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Project set-up
 If you're using a Gradle-based project, then you can add SCV as a dependency directly:
 
 ~~~
-compile 'com.github.amlcurran.showcaseview:library:5.0.0'
+compile 'com.github.amlcurran.showcaseview:library:5.3.0'
 ~~~
 
 If you're using Maven (but not Gradle), you can add the APKlib as a dependency:
@@ -26,7 +26,7 @@ If you're using Maven (but not Gradle), you can add the APKlib as a dependency:
 <dependency>
   <groupId>com.github.amlcurran.showcaseview</groupId>
   <artifactId>library</artifactId>
-  <version>5.0.0</version>
+  <version>5.3.0</version>
   <type>apklib</type>
 </dependency>
 ~~~


### PR DESCRIPTION
Version 5.0.0 does not contain some of the methods being used in the samples. Led me to confusion until I noticed there was a newer version than the one suggested in readme.