### PR TITLE
Offset touch position by window position

### DIFF
--- a/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
@@ -368,8 +368,8 @@ public class ShowcaseView extends RelativeLayout
             return true;
         }
 
-        float xDelta = Math.abs(motionEvent.getRawX() - showcaseX);
-        float yDelta = Math.abs(motionEvent.getRawY() - showcaseY);
+        float xDelta = Math.abs(motionEvent.getRawX() - positionInWindow[0] - showcaseX);
+        float yDelta = Math.abs(motionEvent.getRawY() - positionInWindow[1] - showcaseY);
         double distanceFromFocus = Math.sqrt(Math.pow(xDelta, 2) + Math.pow(yDelta, 2));
 
         if (MotionEvent.ACTION_UP == motionEvent.getAction() &&


### PR DESCRIPTION
When the showcase circle is small and block radius is small, touch event on the bottom area of circle is consumed.
I cannot touch the edit button as following image.

![touch_bottom](https://cloud.githubusercontent.com/assets/8557855/11457314/ea94ecd2-96e8-11e5-8fe1-799d6355a51a.png)

Because `ShowcaseView#showcaseY` is offset by window position in `ShowcaseView#setShowcasePosition(int,int)`, but touch point is calculated in screen and compare these.
