### PR TITLE
Fix incorrect start position of showcase animation

### DIFF
--- a/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
@@ -225,19 +225,21 @@ public class ShowcaseView extends RelativeLayout
     }
 
     public void setShowcaseX(int x) {
-        setShowcasePosition(x, showcaseY);
+        setShowcasePosition(x, getShowcaseY());
     }
 
     public void setShowcaseY(int y) {
-        setShowcasePosition(showcaseX, y);
+        setShowcasePosition(getShowcaseX(), y);
     }
 
     public int getShowcaseX() {
-        return showcaseX;
+        getLocationInWindow(positionInWindow);
+        return showcaseX + positionInWindow[0];
     }
 
     public int getShowcaseY() {
-        return showcaseY;
+        getLocationInWindow(positionInWindow);
+        return showcaseY + positionInWindow[1];
     }
 
     /**


### PR DESCRIPTION
This PR fixes #372.

`ShowcaseView#setShowcasePosition` adjusts the given coordinates for the location of the ShowcaseView inside the window.
When ObjectAnimator calls `getShowcaseY` to get the starting value for the animation, the already adjusted value was returned, thus basically incorrectly applying the adjustment twice when the ObjectAnimator sets that value at the start of the animation.
In effect, `setShowcaseY(getShowcaseY())` changed the value of `showcaseY`.

As a fix, hide the fact that the fields `showcaseX` and `showcaseY` are adjusted by returning the un-adjusted values from their getters.